### PR TITLE
morebikes: Close aiohttp connections when probing API

### DIFF
--- a/custom_components/stromer/config_flow.py
+++ b/custom_components/stromer/config_flow.py
@@ -31,10 +31,12 @@ async def validate_input(_: HomeAssistant, data: dict[str, Any]) -> dict:
     client_id = data[CONF_CLIENT_ID]
     client_secret = data.get(CONF_CLIENT_SECRET, None)
 
-    # Initialize connection to stromer
+    # Initialize connection to stromer to validate credentials
     stromer = Stromer(username, password, client_id, client_secret)
     if not await stromer.stromer_connect():
         raise InvalidAuth
+    LOGGER.debug("Credentials validated successfully")
+    await stromer.stromer_disconnect()
 
     # All bikes information available
     all_bikes = await stromer.stromer_detect()

--- a/custom_components/stromer/config_flow.py
+++ b/custom_components/stromer/config_flow.py
@@ -67,7 +67,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
         self.user_input_data["nickname"] = nickname
         self.user_input_data["model"] = self.all_bikes[bike_id]["biketype"]
 
-        LOGGER.info(f"Using {selected_bike} (i.e. bike ID {bike_id} to talk to the Stromer API")
+        LOGGER.info(f"Using {selected_bike} (i.e. bike ID {bike_id}) to talk to the Stromer API")
 
         await self.async_set_unique_id(f"stromerbike-{bike_id}")
         self._abort_if_unique_id_configured()

--- a/custom_components/stromer/stromer.py
+++ b/custom_components/stromer/stromer.py
@@ -27,6 +27,8 @@ class Stromer:
             self._api_version = "v3"
         self.base_url: str = "https://api3.stromer-portal.ch"
 
+        LOGGER.debug("Initializing Stromer with API version %s", self._api_version)
+
         self._timeout: int = timeout
         self._username: str = username
         self._password: str = password
@@ -43,6 +45,7 @@ class Stromer:
 
     async def stromer_connect(self) -> dict:
         """Connect to stromer API."""
+        LOGGER.debug("Creating aiohttp session")
         aio_timeout = aiohttp.ClientTimeout(total=self._timeout)
         self._websession = aiohttp.ClientSession(timeout=aio_timeout)
 
@@ -55,6 +58,11 @@ class Stromer:
         LOGGER.debug("Stromer connected!")
 
         return True
+
+    async def stromer_disconnect(self) -> None:
+        """Close API web session."""
+        LOGGER.debug("Closing aiohttp session")
+        await self._websession.close()
 
     async def stromer_detect(self) -> dict:
         """Get full data (to determine bike(s))."""


### PR DESCRIPTION
This resolves the following warnings in the log, caused by the probing of credentials during initialization:

```
2024-08-18 19:28:37.026 ERROR (MainThread) [homeassistant] Error doing job: Unclosed client session (None)
2024-08-18 19:28:37.029 ERROR (MainThread) [homeassistant] Error doing job: Unclosed connector (None)
```

Note: If I understand the code correctly, this is only relevant during input validation. During initialization on the other hand, the session is not dropped but is transferred to the data update coordinator and lives on. (It is potentially recreated after 5 failed API update attempts.) Is that correct?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `stromer_disconnect` method to properly manage API session disconnections.
- **Improvements**
	- Enhanced logging for credential validation and connection processes for better operational transparency.
	- Improved clarity in code comments and logging statements for easier debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->