### PR TITLE
Fix timestamp timezone

### DIFF
--- a/custom_components/stromer/sensor.py
+++ b/custom_components/stromer/sensor.py
@@ -210,26 +210,13 @@ class StromerSensor(StromerEntity, SensorEntity):  # type: ignore[misc]
         self.entity_description = description
         self._attr_unique_id = f"{device_id}-{description.key}"
 
-    @staticmethod
-    def _ensure_timezone(timestamp: datetime | None) -> datetime | None:
-        """Calculate days left until domain expires."""
-        if timestamp is None:
-            return None
-
-        # If timezone info isn't provided by the Whois, assume UTC.
-        if timestamp.tzinfo is None:
-            return timestamp.replace(tzinfo=UTC)
-
-        return timestamp
-
     @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
         if self.entity_description.device_class == SensorDeviceClass.TIMESTAMP:
-            return self._ensure_timezone(
-                datetime.fromtimestamp(
-                    int(self._coordinator.data.bikedata.get(self._ent))
-                )
+            return datetime.fromtimestamp(
+                int(self._coordinator.data.bikedata.get(self._ent)),
+                tz=UTC,
             )
 
         return self._coordinator.data.bikedata.get(self._ent)


### PR DESCRIPTION
The code wrongly assumed that the value returned by `datetime.fromtimestamp(ts)` returns a UTC datetime. However, the returned datetime is a naive datetime in the local timezone. The code would then previously replace the missing timezone with UTC.

For example, when running the code in CEST (UTC+2), this resulted in all timestamps being shifted two hours in the future.

Instead, we can pass the UTC timezone directly as `tz` kwarg to `datetime.fromtimestamp`, resulting in a non-naive datetime that has the correct timezone attached.

An alternative approach would have been the following call:

    datetime.fromtimestamp(ts).astimezone()

...however using UTC based datetimes seems cleaner to me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Streamlined the timestamp handling process to ensure consistent UTC timezone conversion without the need for an additional method, enhancing performance and readability. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->