### PR TITLE
Remove deprecated via_device constant as suggested by Dosu

### DIFF
--- a/custom_components/stromer/entity.py
+++ b/custom_components/stromer/entity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.const import ATTR_NAME, ATTR_VIA_DEVICE
+from homeassistant.const import ATTR_NAME
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -40,7 +40,6 @@ class StromerEntity(CoordinatorEntity[StromerData]):  # type:ignore [misc]
         self._attr_device_info.update(
             {
                 ATTR_NAME: data.get("bike_name"),
-                ATTR_VIA_DEVICE: None,
             }
         )
 


### PR DESCRIPTION
Closes #329 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Stromer device information handling to improve compatibility with current Home Assistant behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->